### PR TITLE
Prevent Arrows Keys and Spacebar scrolling the page.

### DIFF
--- a/WebGLxna/wwwroot/index.html
+++ b/WebGLxna/wwwroot/index.html
@@ -65,6 +65,12 @@
             window.theInstance.invokeMethod('TickDotNet');
             window.requestAnimationFrame(tickJS);
         }
+        
+        window.addEventListener("keydown", function(e) {
+            if ([32, 37, 38, 39, 40].indexOf(e.keyCode) > -1) {
+                e.preventDefault();
+            }
+        }, false);
 
         window.initRenderJS = (instance) =>
         {


### PR DESCRIPTION
Some website like itch.io does not handle the key event and will scroll down or up the page when a certain key is pressed. This one is to prevent the page being scrolled when those key is pressed.